### PR TITLE
feat: 适配 YankNote 3.35.0 版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "icon": "./icon.png",
   "engines": {
     "node": ">=14.6.0",
-    "yank-note": "^3.29.0"
+    "yank-note": "^3.35.0"
   },
   "themes": [],
   "files": [
@@ -37,7 +37,7 @@
     "@vitejs/plugin-vue": "^2.3.2",
     "@vue/eslint-config-standard": "^6.1.0",
     "@vue/eslint-config-typescript": "^10.0.0",
-    "@yank-note/runtime-api": "^3.30.0",
+    "@yank-note/runtime-api": "^3.35.0",
     "conventional-changelog-cli": "^2.2.2",
     "eslint": "^7.32.0",
     "eslint-plugin-import": "^2.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -403,10 +403,10 @@
   resolved "https://registry.npmmirror.com/@vue/shared/-/shared-3.2.36.tgz#35e11200542cf29068ba787dad57da9bdb82f644"
   integrity sha512-JtB41wXl7Au3+Nl3gD16Cfpj7k/6aCroZ6BbOiCMFCMvrOpkg/qQUXTso2XowaNqBbnkuGHurLAqkLBxNGc1hQ==
 
-"@yank-note/runtime-api@^3.30.0":
-  version "3.30.0"
-  resolved "https://registry.npmmirror.com/@yank-note/runtime-api/-/runtime-api-3.30.0.tgz#8e406145cc1378b7a5ca8ec638b9290bcdc2ef87"
-  integrity sha512-JoAgYnodMEAOdjldmVde0mv2PG7mKhXVSepVDoKSHiZ3gBo7tIM9b1Rx4YuoHsl9roQAYkeQWL3jTe+gy9l0yg==
+"@yank-note/runtime-api@^3.35.0":
+  version "3.35.0"
+  resolved "https://registry.npmmirror.com/@yank-note/runtime-api/-/runtime-api-3.35.0.tgz#98305503e286f21b915101deab634152e90640dc"
+  integrity sha512-PHObJX/Cz4oI4AyktOxEon6GpEg67PTIMas9+INgvTnFwHmrag0c0WUTbhBcZmcqkPd29p+r5QZofHfA4/E8+w==
   dependencies:
     fs-extra "^10.1.0"
 


### PR DESCRIPTION
Yank Note 3.35.0 版本更改了状态栏菜单中“文档信息”的实现，Vim 扩展原有的 hack 实现已不能正常工作。

https://github.com/purocean/yn/releases/tag/v3.35.0

另外状态栏菜单 API 增加了实用 Vue 组件来自定义标题，所以适配一下。